### PR TITLE
[dev] Format mobile view

### DIFF
--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -14,6 +14,7 @@ class HomePage extends React.Component {
                 'SampleX4']
         }
     }
+
     render() {
         return (
 
@@ -22,12 +23,14 @@ class HomePage extends React.Component {
                 <Row>
                     <Col>This is is the Home Page and This coding style should be followed</Col>
                 </Row>
-                <div style={{ display: "flex" }}>
-                    <div style={{ flex: 1 }}>
-                        <Charts chartType="Line" labels={this.state.labels} title="Sample 1" data={this.state.data} options={{}} />
-                    </div>
-                    <div style={{ flex: 1 }}>
-                        <Charts chartType="Bar" labels={this.state.labels} title="Sample 2" data={this.state.data} options={{}} />
+                <div className="container-fluid">
+                    <div className="row">
+                        <div className="col-sm-6 bg-success">
+                            <Charts chartType="Line" labels={this.state.labels} title="Sample 1" data={this.state.data} options={{}} />
+                        </div>  
+                        <div className="col-sm-6 bg-warning">
+                            <Charts chartType="Bar" labels={this.state.labels} title="Sample 2" data={this.state.data} options={{}} />
+                        </div>  
                     </div>
                 </div>
                 <Footer />

--- a/src/pages/HomePage/HomePage.js
+++ b/src/pages/HomePage/HomePage.js
@@ -25,10 +25,10 @@ class HomePage extends React.Component {
                 </Row>
                 <div className="container-fluid">
                     <div className="row">
-                        <div className="col-sm-6 bg-success">
+                        <div className="col-sm-6">
                             <Charts chartType="Line" labels={this.state.labels} title="Sample 1" data={this.state.data} options={{}} />
                         </div>  
-                        <div className="col-sm-6 bg-warning">
+                        <div className="col-sm-6">
                             <Charts chartType="Bar" labels={this.state.labels} title="Sample 2" data={this.state.data} options={{}} />
                         </div>  
                     </div>


### PR DESCRIPTION
# Description

Charts are now responsive and formatted correctly.  They will be stacked below 576px width and side-by-side above that.  I used bootstrap classes.

Fixes # 41

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ X] This PR is made on develop branch
- [ X] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

## Reviewer: [Ayan Biswas](https://github.com/ayan-biswas0412)

## Screenshots
<img width="150" alt="Screen Shot 2020-10-17 at 10 35 10 AM" src="https://user-images.githubusercontent.com/34319929/96339752-88090a80-1064-11eb-896a-6def467017a4.png">
<img width="200" alt="Screen Shot 2020-10-17 at 10 35 25 AM" src="https://user-images.githubusercontent.com/34319929/96339753-88090a80-1064-11eb-9ba9-d77248399fdf.png">
